### PR TITLE
fix:  cannot read slice of undefined Error

### DIFF
--- a/packages/esbuild-plugin-copy/src/lib/handler.ts
+++ b/packages/esbuild-plugin-copy/src/lib/handler.ts
@@ -50,6 +50,10 @@ export function copyOperationHandler(
     // globbedFromPath: /PATH/TO/assets/nest/foo.js → /nest/foo.js
     const [, preservedDirStructure] = globbedFromPath.split(startFragment);
 
+    if (!preservedDirStructure) {
+      continue;
+    }
+
     // /PATH/TO/assets/foo.js
     // path.resolve seems to be unnecessary as globbed path is already absolute path
     const sourcePath = path.resolve(globbedFromPath);


### PR DESCRIPTION
when I have config like this: 
```
assets: {
    from: [
        'node_modules/[some-library-1]/filename',
        'node_modules/[some-library-2]/filename',
    ],
    to: ['dist']
},
```

I have an error "Cannot read slice of undefined". With this "continue" statement from my commit all the files are being copied without any errors.

PS: I don't see why in esbuild-plugin-copy.ts file you call "copyOperationHandler" for every item in "to" array in a loop for every item in "from" array and then inside "copyOperationHandler" function you run a loop for "from" paths again.
There won't be this error without this inner loop inside "copyOperationHandler".
But I believe there is a reason for this logic:) cheers